### PR TITLE
Fix: Update access to `best_iteration` in `xgb.cv` results (xgboost v2+)

### DIFF
--- a/R/bcds.R
+++ b/R/bcds.R
@@ -92,7 +92,7 @@ bcds <- function(sce, ntop=500, srat=1, verb=FALSE, retRes=FALSE,
     res = xgb.cv(data =mm, nthread = 2, nrounds = 500, objective = "binary:logistic",
                  nfold=5,metrics=list("error"),prediction=TRUE,
                  early_stopping_rounds=2, tree_method="hist",subsample=0.5,verbose=0)
-    ni  = res$best_iteration
+    ni  = res$early_stop$best_iteration
     ac  = res$evaluation_log$test_error_mean[ni] + 1*res$evaluation_log$test_error_std[ni]
     ni  = min(which( res$evaluation_log$test_error_mean <= ac  ))
     nmax = ni


### PR DESCRIPTION
When using the scds package installed from bioconda, it installs xgboost v2.1 from conda-forge. This newer xgboost version introduced syntax changes affecting the `bcds` function. Specifically, `best_iteration` is now stored under `early_stop`, as per the changes in this xgboost PR: https://github.com/dmlc/xgboost/pull/9403.

Therefore, this PR updates `nmax` assignment to access best_iteration from `res$early_stop$best_iteration` instead of directly from res.

This update ensures that scds can work seamlessly with the bioconda xgboost v2.1 version, preventing errors during cross-validation with early stopping. Notably, CRAN's xgboost version remains older than v2.1 and still supports the original syntax, so this change specifically addresses compatibility for bioconda users.
